### PR TITLE
Change badge for Java CI and codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
+[![CI Status](https://github.com/AY2122S1-CS2103-T16-4/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2122S1-CS2103-T16-4/tp/actions)
 
 ![Ui](docs/images/Ui.png)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ title: AddressBook Level-3
 ---
 
 [![CI Status](https://github.com/AY2122S1-CS2103-T16-4/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2122S1-CS2103-T16-4/tp/actions)
-[![codecov](https://codecov.io/gh/AY2122S1-CS2103-T16-4/tp/branch/master/graph/badge.svg)](https://codecov.io/gh/AY2122S1-CS2103-T16-4/tp)
+[![codecov](https://codecov.io/gh/AY2122S1-CS2103-T16-4/tp/branch/master/graph/badge.svg?token=T8S6E582CP)](https://codecov.io/gh/AY2122S1-CS2103-T16-4/tp)
 
 ![Ui](images/Ui.png)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: page
 title: AddressBook Level-3
 ---
 
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
-[![codecov](https://codecov.io/gh/se-edu/addressbook-level3/branch/master/graph/badge.svg)](https://codecov.io/gh/se-edu/addressbook-level3)
+[![CI Status](https://github.com/AY2122S1-CS2103-T16-4/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2122S1-CS2103-T16-4/tp/actions)
+[![codecov](https://codecov.io/AY2122S1-CS2103-T16-4/tp/branch/master/graph/badge.svg)](https://codecov.io/gh/AY2122S1-CS2103-T16-4/tp)
 
 ![Ui](images/Ui.png)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ title: AddressBook Level-3
 ---
 
 [![CI Status](https://github.com/AY2122S1-CS2103-T16-4/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2122S1-CS2103-T16-4/tp/actions)
-[![codecov](https://codecov.io/AY2122S1-CS2103-T16-4/tp/branch/master/graph/badge.svg)](https://codecov.io/gh/AY2122S1-CS2103-T16-4/tp)
+[![codecov](https://codecov.io/gh/AY2122S1-CS2103-T16-4/tp/branch/master/graph/badge.svg)](https://codecov.io/gh/AY2122S1-CS2103-T16-4/tp)
 
 ![Ui](images/Ui.png)
 


### PR DESCRIPTION
Once this PR is merged, the CI will run on the master branch, pushing the codecov report to codecov, and we should be able to see the coverage at https://app.codecov.io/gh/AY2122S1-CS2103-T16-4/tp

You can see the codecov for this branch over here https://app.codecov.io/gh/AY2122S1-CS2103-T16-4/tp/branch/branch-setup-ci

I believe the badge tracks the codecov on the master branch which hasn't ran yet (should automatically run if this PR is merged to master). Here is the badge for this branch `branch-setup-ci` https://codecov.io/gh/AY2122S1-CS2103-T16-4/tp/branch/branch-setup-ci/graph/badge.svg

The codecov report below is showing a diff coverage of n/a because master has not yet uploaded any reports to codecov