### PR TITLE
Fix bug in details command

### DIFF
--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -37,6 +37,16 @@ public class PersonListPanel extends UiPart<Region> {
      */
     public void setShowDetails(boolean showDetails) {
         this.showDetails = showDetails;
+        refresh();
+    }
+
+    /**
+     * Refreshes the entire component.
+     */
+    public void refresh() {
+        personListView.setItems(personListView.getItems());
+        personListView.setCellFactory(listView -> new PersonListViewCell());
+        personListView.refresh();
     }
 
     /**


### PR DESCRIPTION
Code snippet causing the bug. command result is needed to know if the ui should show persons as details or not. however, when the result is received, the model is updated already (model updates during execution) and setting show details does not update the personlistpanel component, so we have to explicitly tell it to refresh
```java
            CommandResult commandResult = logic.execute(commandText);
            logger.info("Result: " + commandResult.getFeedbackToUser());
            resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());

            if (commandResult.isShowHelp()) {
                handleHelp();
            }

            if (commandResult.isExit()) {
                handleExit();
            }

            personListPanel.setShowDetails(commandResult.isShowDetails());
```

The cause of the bug was due to personListPanel not refreshing. Note that calling `personListView.refresh();` is not sufficient to refresh the entire component. setting items and cell factory does a "refresh".

This closes #47 .

