### PR TITLE
Update validation regex for phone

### DIFF
--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -11,8 +11,8 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+            "Phone numbers should only contain numbers, start with 6, 8 or 9, and should be 8 digits long";
+    public static final String VALIDATION_REGEX = "[6,8,9]{1,1}[0-9]{7,7}";
 
     public static final String UNSPECIFIED_INPUT = "No phone number specified";
 

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -3,12 +3,12 @@
     "name": "Valid Person",
     "phone": "9482424",
     "email": "hans@example.com",
-    "address": "4th street"
+    "telegram": "@validPhone"
   }, {
     "name": "Person With Invalid Phone Field",
     "phone": "948asdf2424",
     "email": "hans@example.com",
-    "address": "4th street"
+    "telegram": "@validPhone"
   } ],
   "events": []
 }

--- a/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
@@ -3,7 +3,7 @@
     "name": "Person with invalid name field: Ha!ns Mu@ster",
     "phone": "9482424",
     "email": "hans@example.com",
-    "address": "4th street"
+    "telegram": "@validPhone"
   } ],
   "events": []
 }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -9,7 +9,7 @@
     "name": "Alice Pauline",
     "phone": "94351253",
     "email": "pauline@example.com",
-    "address": "paulinealice"
+    "telegram": "@paulinealice"
   } ],
   "events": []
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -26,19 +26,19 @@
     "tagged" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
-    "phone" : "9482224",
+    "phone" : "94822224",
     "email" : "werner@example.com",
     "telegram" : "@theletterl",
     "tagged" : [ ]
   }, {
     "name" : "Fiona Kunz",
-    "phone" : "9482427",
+    "phone" : "94824327",
     "email" : "lydia@example.com",
     "telegram" : "@princessshrek",
     "tagged" : [ ]
   }, {
     "name" : "George Best",
-    "phone" : "9482442",
+    "phone" : "94824423",
     "email" : "anna@example.com",
     "telegram" : "@georgebestest",
     "tagged" : [ ]

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -35,8 +35,8 @@ public class CommandTestUtil {
 
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
-    public static final String VALID_PHONE_AMY = "11111111";
-    public static final String VALID_PHONE_BOB = "22222222";
+    public static final String VALID_PHONE_AMY = "99999999";
+    public static final String VALID_PHONE_BOB = "88888888";
     public static final String VALID_EMAIL_AMY = "amy@example.com";
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_TELEGRAM_AMY = "@amyamyamy";
@@ -66,7 +66,7 @@ public class CommandTestUtil {
     public static final String INVALID_EVENT_NAME = "WoHoO#$";
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
-    public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
+    public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a1111"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_TELEGRAM; // empty string not allowed for telegram
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -24,14 +24,14 @@ import seedu.address.model.tag.Tag;
 public class ParserUtilTest {
     private static final String INVALID_EVENT_NAME = "$@$%";
     private static final String INVALID_NAME = "R@chel";
-    private static final String INVALID_PHONE = "+651234";
+    private static final String INVALID_PHONE = "11111111";
     private static final String INVALID_TELEGRAM = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_EVENT_NAME = "Cool Event";
     private static final String VALID_NAME = "Rachel Walker";
-    private static final String VALID_PHONE = "123456";
+    private static final String VALID_PHONE = "66666666";
     private static final String VALID_TELEGRAM = "@validTelegram123";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";

--- a/src/test/java/seedu/address/model/person/MatchesKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/MatchesKeywordsPredicateTest.java
@@ -57,14 +57,14 @@ public class MatchesKeywordsPredicateTest {
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Multiple keywords (name, phone, email, telegram)
-        predicate = new MatchesKeywordsPredicate(Arrays.asList("Alice", "54321", "carol@email.com", "@david"));
-        assertTrue(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
+        predicate = new MatchesKeywordsPredicate(Arrays.asList("Alice", "98765432", "carol@email.com", "@alice"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice").withPhone("98765432")
                 .withEmail("alice@email.com").withTelegram("@alice").build()));
-        assertTrue(predicate.test(new PersonBuilder().withName("Bob").withPhone("54321")
+        assertTrue(predicate.test(new PersonBuilder().withName("Bob").withPhone("98765432")
                 .withEmail("bob@email.com").withTelegram("@bob").build()));
-        assertTrue(predicate.test(new PersonBuilder().withName("Carol").withPhone("67890")
+        assertTrue(predicate.test(new PersonBuilder().withName("Carol").withPhone("98765432")
                 .withEmail("carol@email.com").withTelegram("@carol").build()));
-        assertTrue(predicate.test(new PersonBuilder().withName("David").withPhone("09876")
+        assertTrue(predicate.test(new PersonBuilder().withName("David").withPhone("98765432")
                 .withEmail("david@email.com").withTelegram("@david").build()));
     }
 

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -27,14 +27,15 @@ public class PhoneTest {
         // invalid phone numbers
         assertFalse(Phone.isValidPhone("")); // empty string
         assertFalse(Phone.isValidPhone(" ")); // spaces only
-        assertFalse(Phone.isValidPhone("91")); // less than 3 numbers
+        assertFalse(Phone.isValidPhone("91")); // less than 8 numbers
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
+        assertFalse(Phone.isValidPhone("13121534")); // invalid first digit
 
         // valid phone numbers
-        assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
+        assertTrue(Phone.isValidPhone("87654321")); // exactly 3 numbers
         assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("67891223")); // long phone numbers
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -38,17 +38,17 @@ public class TypicalPersons {
             .withEmail("heinz@example.com").withTelegram("@caaarl").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withTelegram("dannyyyyy").withTags("friends").build();
-    public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
+    public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("94822224")
             .withEmail("werner@example.com").withTelegram("theletterl").build();
-    public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
+    public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("94824327")
             .withEmail("lydia@example.com").withTelegram("princessshrek").build();
-    public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
+    public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("94824423")
             .withEmail("anna@example.com").withTelegram("georgebestest").build();
 
     // Manually added
-    public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
+    public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("84824246")
             .withEmail("stefan@example.com").withTelegram("hoonoon").build();
-    public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
+    public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("84821313")
             .withEmail("hans@example.com").withTelegram("idaidaida").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}


### PR DESCRIPTION
Changed validation regex for `Phone` to only match strings that:
- Start with 6, 8, or 9
- Are 8 digits long
- Are numeric

Test cases updated as necessary.

Closes #151 